### PR TITLE
Forum awareness redo

### DIFF
--- a/TidyData.Rmd
+++ b/TidyData.Rmd
@@ -606,3 +606,36 @@ resultsTidy %<>%
 ```
 
 </details>
+
+## AnVIL Forum Awareness and Utilization
+
+The question asked was also pretty granular in describing awareness of and multiple, perhaps co-occurring ways of utilizing the support forum. We want to simplify each set of answers from a respondent to report a binary yes/no they are aware of the forum from the set of responses they selected.
+
+<details><summary>Question and possible answers</summary>
+
+> Have you ever read or posted in our AnVIL Support Forum? (Select all that apply)
+
+Possible answers include
+
+* Read through others' posts 
+* Posted in 
+* Answered someone's post 
+* No, but aware of 
+* No, didn't know of
+
+```{r}
+resultsTidy %<>%
+  mutate(forumAwareness = factor(
+    case_when(
+      str_detect(AnVILSupportForum, "aware of|Answered|Posted|Read") ~ "Aware of",
+      str_detect(AnVILSupportForum, "didn't know of") ~ "Not Aware of"
+    ), levels = c("Not Aware of", "Aware of")),
+         forumUse = factor(
+    case_when(
+      str_detect(AnVILSupportForum, "Answered|Posted|Read") ~ "Have/will utilize",
+      str_detect(AnVILSupportForum, "No, ") ~ "Have not utilized"
+    ), levels = c("Have not utilized", "Have/will utilize"))
+)
+```
+
+</details>

--- a/anvilPoll2024ExtraAnalysis.Rmd
+++ b/anvilPoll2024ExtraAnalysis.Rmd
@@ -590,22 +590,10 @@ pd1 / pd2
 
 ## Awareness: AnVIL Support Forum (supplemental)
 
-```{r}
-forumdf %<>% mutate(,
-        forumUse = factor(
-          case_when(
-          forumInteractionDescription == "Posted in" ~ "Have utilized",
-          forumInteractionDescription == "Answered someone's post" ~ "Have utilized",
-          forumInteractionDescription == "Read through others' posts" ~ "Have utilized",
-          forumInteractionDescription == "No but aware of" ~ "Have not utilized",
-          forumInteractionDescription == "No didn't know of" ~ "Have not utilized"
-        ), levels = c("Have not utilized", "Have utilized")))
-```
-
 ### Utilization
 
 ```{r}
-forumPlotUtil <- forumdf %>%
+forumPlotUtil <- resultsTidy %>%
   group_by(UserType, forumUse) %>%
   summarize(count = n()) %>%
   ggplot(aes(y=reorder(forumUse, count),
@@ -620,7 +608,7 @@ stylize_bar(forumPlotUtil)
 ### Awareness or Utilization Color rather than y-axis split
 
 ```{r}
-pf1 <- forumdf %>%
+pf1 <- resultsTidy %>%
   group_by(UserType, forumUse) %>%
   summarize(count = n()) %>%
   ggplot(aes(y=UserType,
@@ -633,11 +621,11 @@ pf1 <- forumdf %>%
   ylab(" ") +
   scale_fill_manual(values = c("#25445A", "#7EBAC0")) +
   scale_x_continuous(breaks= pretty_breaks()) +
-  theme(legend.title = element_blank(), )
+  theme(legend.title = element_blank())
 ```
 
 ```{r}
-pf2 <- forumdf %>%
+pf2 <- resultsTidy %>%
   group_by(UserType, forumAwareness) %>%
   summarize(count = n()) %>%
   ggplot(aes(y=UserType,

--- a/anvilPoll2024MainAnalysis.Rmd
+++ b/anvilPoll2024MainAnalysis.Rmd
@@ -719,28 +719,20 @@ forumdf <- resultsTidy %>%
                                          replacement= "No ")) %>%
   separate_longer_delim(AnVILSupportForum,
            delim = ", ") %>%
-  group_by(UserType, CurrentUsageDescription, AnVILSupportForum) %>%
+  group_by(UserType, AnVILSupportForum) %>%
   summarize(count = n()) %>%
   drop_na() %>%
-  mutate(forumInteractionDescription =
+  mutate(AnVILSupportForum =
            factor(AnVILSupportForum,
-                  levels = c("Posted in", "Answered someone's post", "Read through others' posts", "No but aware of", "No didn't know of")),
-        forumAwareness = factor(
-          case_when(
-          forumInteractionDescription == "Posted in" ~ "Aware of",
-          forumInteractionDescription == "Answered someone's post" ~ "Aware of",
-          forumInteractionDescription == "Read through others' posts" ~ "Aware of",
-          forumInteractionDescription == "No but aware of" ~ "Aware of",
-          forumInteractionDescription == "No didn't know of" ~ "Not Aware of"
-        ), levels = c("Not Aware of", "Aware of"))
-)
+                  levels = c("Posted in", "Answered someone's post", "Read through others' posts", "No but aware of", "No didn't know of"))
+         )
 ```
 
 #### Raw responses
 
 ```{r}
 forumPlotRaw <- ggplot(forumdf,
-                       aes(y = reorder(forumInteractionDescription, count),
+                       aes(y = reorder(AnVILSupportForum, count),
                            x = count,
                            fill = UserType)) +
   geom_bar(stat = "identity") +
@@ -754,8 +746,8 @@ forumPlotRaw
 #### Responses recoded to focus on awareness
 
 ```{r}
-forumPlot <- ggplot(forumdf, aes(y = forumAwareness, x = count, fill = UserType)) +
-  geom_bar(stat = "identity") +
+forumPlot <- ggplot(resultsTidy, aes(y = forumAwareness, fill = UserType)) +
+  geom_bar() +
   ggtitle("Have you ever read or posted in our AnVIL Support Forum?")
 
 forumPlot %<>% stylize_bar(ylabel = "Awareness")


### PR DESCRIPTION
Per Issue #19, redid forum awareness and utilization graphs so that the summaries give a single binary aware/not aware etc to each respondent pooled response rather than reporting each individual/separated out choice