### PR TITLE
free x in kind of work plot

### DIFF
--- a/anvilPoll2024MainAnalysis.Rmd
+++ b/anvilPoll2024MainAnalysis.Rmd
@@ -154,7 +154,7 @@ kowPlot <- ggplot(dfForPlotKOW,
   ylab("") +
   ggtitle("What kind of work do you do?") +
   xlab("Respondent") +
-  facet_wrap(~UserType)
+  facet_wrap(~UserType, scales = "free_x")
 
 kowPlot
 


### PR DESCRIPTION
This plot was originally plotting every timestamp for both potential and current (no fill if timestamp didn't go with a potential user). Used `scales=free_x` to fix.